### PR TITLE
Annotations override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+- The Puppet node name can now be overridden using entities annotations
+
 ## [0.1.0] - 2020-02-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ Available Commands:
   version     Print the version number of this plugin
 
 Flags:
-      --cacert string              path to the site's Puppet CA certificate PEM file
+      --ca-cert string             path to the site's Puppet CA certificate PEM file
       --cert string                path to the SSL certificate PEM file signed by your site's Puppet CA
   -e, --endpoint string            the PuppetDB API endpoint (URL). If an API path is not specified, /pdb/query/v4/nodes/ will be used
   -h, --help                       help for sensu-puppet-handler
       --insecure-skip-tls-verify   skip SSL verification
       --key string                 path to the private key PEM file for that certificate
+      --node-name string           node name to use for the entity when querying PuppetDB
   -a, --sensu-api-key string       The Sensu API key
   -u, --sensu-api-url string       The Sensu API URL (default "http://localhost:8080")
   -c, --sensu-ca-cert string       The Sensu Go CA Certificate
@@ -96,11 +97,22 @@ spec:
   type: set
 ```
 
-
 ### Check definition
 
 No check definition is needed. This handler will only trigger on keepalive
 events after it is added to the keepalive handler set.
+
+### Puppet node name
+
+When querying PuppetDB for a node, by default, Sensu will use the Sensu entity’s
+name for the Puppet node name. Individual Sensu entities can override the name
+of their corresponding Puppet node, using annotations:
+
+```yml
+# /etc/sensu/agent.yml example
+annotations:
+  sensu.io/plugins/sensu-puppet-handler/config/node-name: webserver01.example.com
+```
 
 ## Installing from source and contributing
 

--- a/main.go
+++ b/main.go
@@ -236,7 +236,6 @@ func puppetNodeExists(client *http.Client, event *types.Event) (bool, error) {
 	if handler.puppetNodeName == "" {
 		name = event.Entity.Name
 	}
-	fmt.Println(name)
 
 	// Get the puppet node
 	endpoint := strings.TrimRight(handler.endpoint, "/")

--- a/main.go
+++ b/main.go
@@ -26,14 +26,14 @@ type Handler struct {
 	puppetKey                string
 	puppetCACert             string
 	puppetInsecureSkipVerify bool
+	puppetNodeName           string
 	sensuAPIURL              string
 	sensuAPIKey              string
 	sensuCACert              string
 }
 
 const (
-	defaultAPIPath      = "pdb/query/v4/nodes"
-	labelPuppetNodeName = "puppet_node_name"
+	defaultAPIPath = "pdb/query/v4/nodes"
 )
 
 var (
@@ -81,6 +81,13 @@ var (
 			Argument: "insecure-skip-tls-verify",
 			Usage:    "skip SSL verification",
 			Value:    &handler.puppetInsecureSkipVerify,
+		},
+		&sensu.PluginConfigOption{
+			Path:     "node-name",
+			Env:      "PUPPET_NODE_NAME",
+			Argument: "node-name",
+			Usage:    "node name to use for the entity when querying PuppetDB",
+			Value:    &handler.puppetNodeName,
 		},
 		{
 			Path:      "sensu-api-url",
@@ -196,13 +203,13 @@ func puppetHTTPClient() (*http.Client, error) {
 	// Load the public/private key pair
 	cert, err := tls.LoadX509KeyPair(handler.puppetCert, handler.puppetKey)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not read the certificate/key: %s", err)
 	}
 
 	// Load the CA certificate
 	caCert, err := ioutil.ReadFile(handler.puppetCACert)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not read the CA certificate: %s", err)
 	}
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)
@@ -223,11 +230,13 @@ func puppetHTTPClient() (*http.Client, error) {
 // encountered. The Puppet node name defaults to the entity name but can be
 // overriden through the entity label "puppet_node_name"
 func puppetNodeExists(client *http.Client, event *types.Event) (bool, error) {
-	// Determine the Puppet node name
-	name := event.Entity.Name
-	if event.Entity.Labels[labelPuppetNodeName] != "" {
-		name = event.Entity.Labels[labelPuppetNodeName]
+	// Determine the Puppet node name via the annotations and fallback to the
+	// entity name
+	name := handler.puppetNodeName
+	if handler.puppetNodeName == "" {
+		name = event.Entity.Name
 	}
+	fmt.Println(name)
 
 	// Get the puppet node
 	endpoint := strings.TrimRight(handler.endpoint, "/")


### PR DESCRIPTION
It allows and documents the configuration of the Puppet node name via entities annotations.