### PR TITLE
Removing `is_incident` filter from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ spec:
   - PUPPET_CERT=/path/to/puppet/cert.pem
   - PUPPET_KEY=/path/to/puppet/key.pem
   - PUPPET_CA_CERT=/path/to/puppet/ca.pem
-  filters:
-  - is_incident
   runtime_assets:
   - sensu/sensu-puppet-handler
   secrets:


### PR DESCRIPTION
Keepalives are treated differently from events in that they're not treated as incidents. Adding this filter will ensure that the event is never handled.